### PR TITLE
fix: 非720p分辨率下坐标映射 & minitouch 兼容

### DIFF
--- a/module/device/control.py
+++ b/module/device/control.py
@@ -43,7 +43,6 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
         if control_check:
             self.handle_control_check(button)
         x, y = random_rectangle_point(button.button)
-        x, y = self._map_coord(x, y)  # Add by MHY, 非720p坐标反向映射
         x, y = ensure_int(x, y)
         logger.info(
             'Click %s @ %s' % (point2str(x, y), button)
@@ -74,7 +73,6 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
         """
         self.handle_control_check(button)
         x, y = random_rectangle_point(button.button)
-        x, y = self._map_coord(x, y)  # Add by MHY, 非720p坐标反向映射
         x, y = ensure_int(x, y)
         duration = ensure_time(duration)
         logger.info(
@@ -96,8 +94,6 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
 
     def swipe(self, p1, p2, duration=(0.1, 0.2), name='SWIPE', distance_check=True):
         self.handle_control_check(name)
-        p1 = self._map_coord(*p1)  # Add by MHY, 非720p坐标反向映射
-        p2 = self._map_coord(*p2)
         p1, p2 = ensure_int(p1, p2)
         duration = ensure_time(duration)
         method = self.config.Emulator_ControlMethod
@@ -161,8 +157,6 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
     def drag(self, p1, p2, segments=1, shake=(0, 15), point_random=(-10, -10, 10, 10), shake_random=(-5, -5, 5, 5),
              swipe_duration=0.25, shake_duration=0.1, name='DRAG'):
         self.handle_control_check(name)
-        p1 = self._map_coord(*p1)  # Add by MHY, 非720p坐标反向映射
-        p2 = self._map_coord(*p2)
         p1, p2 = ensure_int(p1, p2)
         logger.info(
             'Drag %s -> %s' % (point2str(*p1), point2str(*p2))

--- a/module/device/control.py
+++ b/module/device/control.py
@@ -15,6 +15,13 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
         # Will be overridden in Device
         pass
 
+    # Add by MHY, 非720p分辨率下将720p空间坐标反向映射到实际屏幕坐标
+    # 后续上游如果提供完整的坐标映射方案，可对比后选择采用上游方案或保留当前方案
+    def _map_coord(self, x, y):
+        sx = getattr(self, '_screen_scale_x', 1.0)
+        sy = getattr(self, '_screen_scale_y', 1.0)
+        return x * sx, y * sy
+
     @cached_property
     def click_methods(self):
         return {
@@ -36,6 +43,7 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
         if control_check:
             self.handle_control_check(button)
         x, y = random_rectangle_point(button.button)
+        x, y = self._map_coord(x, y)  # Add by MHY, 非720p坐标反向映射
         x, y = ensure_int(x, y)
         logger.info(
             'Click %s @ %s' % (point2str(x, y), button)
@@ -66,6 +74,7 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
         """
         self.handle_control_check(button)
         x, y = random_rectangle_point(button.button)
+        x, y = self._map_coord(x, y)  # Add by MHY, 非720p坐标反向映射
         x, y = ensure_int(x, y)
         duration = ensure_time(duration)
         logger.info(
@@ -87,6 +96,8 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
 
     def swipe(self, p1, p2, duration=(0.1, 0.2), name='SWIPE', distance_check=True):
         self.handle_control_check(name)
+        p1 = self._map_coord(*p1)  # Add by MHY, 非720p坐标反向映射
+        p2 = self._map_coord(*p2)
         p1, p2 = ensure_int(p1, p2)
         duration = ensure_time(duration)
         method = self.config.Emulator_ControlMethod
@@ -150,6 +161,8 @@ class Control(Hermit, Minitouch, Scrcpy, MaaTouch, NemuIpc):
     def drag(self, p1, p2, segments=1, shake=(0, 15), point_random=(-10, -10, 10, 10), shake_random=(-5, -5, 5, 5),
              swipe_duration=0.25, shake_duration=0.1, name='DRAG'):
         self.handle_control_check(name)
+        p1 = self._map_coord(*p1)  # Add by MHY, 非720p坐标反向映射
+        p2 = self._map_coord(*p2)
         p1, p2 = ensure_int(p1, p2)
         logger.info(
             'Drag %s -> %s' % (point2str(*p1), point2str(*p2))

--- a/module/device/method/adb.py
+++ b/module/device/method/adb.py
@@ -200,6 +200,8 @@ class Adb(Connection):
 
     @retry
     def click_adb(self, x, y):
+        # Add by MHY, ADB input tap 使用物理坐标，非720p屏幕需映射；minitouch等已有内置映射的后端不做此处理
+        x, y = self._map_coord(x, y)
         start = time.time()
         self.adb_shell(['input', 'tap', x, y])
         if time.time() - start <= 0.05:
@@ -207,6 +209,9 @@ class Adb(Connection):
 
     @retry
     def swipe_adb(self, p1, p2, duration=0.1):
+        # Add by MHY, ADB input swipe 使用物理坐标，非720p屏幕需映射
+        p1 = self._map_coord(*p1)
+        p2 = self._map_coord(*p2)
         duration = int(duration * 1000)
         self.adb_shell(['input', 'swipe', *p1, *p2, duration])
 

--- a/module/device/method/scrcpy/scrcpy.py
+++ b/module/device/method/scrcpy/scrcpy.py
@@ -113,6 +113,8 @@ class Scrcpy(ScrcpyCore, Uiautomator2):
 
     @retry
     def click_scrcpy(self, x, y):
+        # Add by MHY, scrcpy 发送原始像素坐标，非720p屏幕需映射
+        x, y = self._map_coord(x, y)
         self.scrcpy_ensure_running()
 
         with self._scrcpy_control_socket_lock:
@@ -122,6 +124,8 @@ class Scrcpy(ScrcpyCore, Uiautomator2):
 
     @retry
     def long_click_scrcpy(self, x, y, duration=1.0):
+        # Add by MHY, scrcpy 发送原始像素坐标，非720p屏幕需映射
+        x, y = self._map_coord(x, y)
         self.scrcpy_ensure_running()
 
         with self._scrcpy_control_socket_lock:
@@ -132,6 +136,9 @@ class Scrcpy(ScrcpyCore, Uiautomator2):
 
     @retry
     def swipe_scrcpy(self, p1, p2):
+        # Add by MHY, scrcpy 发送原始像素坐标，非720p屏幕需映射
+        p1 = self._map_coord(*p1)
+        p2 = self._map_coord(*p2)
         self.scrcpy_ensure_running()
 
         with self._scrcpy_control_socket_lock:
@@ -150,6 +157,9 @@ class Scrcpy(ScrcpyCore, Uiautomator2):
 
     @retry
     def drag_scrcpy(self, p1, p2, point_random=(-10, -10, 10, 10)):
+        # Add by MHY, scrcpy 发送原始像素坐标，非720p屏幕需映射
+        p1 = self._map_coord(*p1)
+        p2 = self._map_coord(*p2)
         self.scrcpy_ensure_running()
 
         with self._scrcpy_control_socket_lock:

--- a/module/device/method/uiautomator_2.py
+++ b/module/device/method/uiautomator_2.py
@@ -154,14 +154,21 @@ class Uiautomator2(Connection):
 
     @retry
     def click_uiautomator2(self, x, y):
+        # Add by MHY, uiautomator2 底层使用 input tap，非720p屏幕需映射
+        x, y = self._map_coord(x, y)
         self.u2.click(x, y)
 
     @retry
     def long_click_uiautomator2(self, x, y, duration=(1, 1.2)):
+        # Add by MHY, uiautomator2 底层使用 input swipe，非720p屏幕需映射
+        x, y = self._map_coord(x, y)
         self.u2.long_click(x, y, duration=duration)
 
     @retry
     def swipe_uiautomator2(self, p1, p2, duration=0.1):
+        # Add by MHY, uiautomator2 底层使用 input swipe，非720p屏幕需映射
+        p1 = self._map_coord(*p1)
+        p2 = self._map_coord(*p2)
         self.u2.swipe(*p1, *p2, duration=duration)
 
     @retry

--- a/module/device/screenshot.py
+++ b/module/device/screenshot.py
@@ -47,6 +47,8 @@ class Screenshot(Adb, WSA, DroidCast, AScreenCap, Scrcpy, NemuIpc, LDOpenGL):
     _screenshot_interval = Timer(0.1)
     _last_save_time = {}
     _resize_method_idx = 0
+    _screen_scale_x = 1.0   # Add by MHY, 非720p屏幕的坐标缩放因子，click/swipe前反向映射使用
+    _screen_scale_y = 1.0
     image: np.ndarray
 
     cv_interpolation_methods = [cv2.INTER_LANCZOS4, cv2.INTER_AREA]
@@ -117,6 +119,10 @@ class Screenshot(Adb, WSA, DroidCast, AScreenCap, Scrcpy, NemuIpc, LDOpenGL):
 
             width, height = image_size(self.image)
             if width != 1280 or height != 720:
+                # Add by MHY, 记录原始分辨率→720p的缩放因子，供click/swipe等坐标反向映射
+                # 后续上游如果提供完整的坐标映射方案，可对比后选择采用上游方案或保留当前方案
+                self._screen_scale_x = width / 1280.0
+                self._screen_scale_y = height / 720.0
                 method_type, interp = self.get_next_resize_method()
                 if method_type == 'cv':
                     self.image = cv2.resize(self.image, (1280, 720), interpolation=interp)


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                 
  - 截图 resize 至 720p 前记录缩放因子，click/swipe 前反向映射到实际屏幕坐标                                                                                                                                                                                                                             
  - 适配 ADB、uiautomator2、scrcpy 后端（minitouch/MaaTouch 已有内置映射，不做重复处理）                                                                                                                                                                                                                 
  - 支持 1920x1080、2560x1440、3840x2160 等所有 16:9 分辨率 