### PR TITLE
feat: 困难图均衡模式 + merge upstream_nanoda/master

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,5 @@
+# Cursor Helper Version: 0.1.5
+# 保留 Cursor Helper 与 .cursor 目录
+!cursor-helper/
+!.cursor/rules/
+!.cursor/commands/

--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,34 @@ pyrightconfig.json
 /f
 /workers
 /debug_img
+
+# Cursor Helper Version: 0.1.5
+# Cursor Helper AI 相关文件
+# 忽略 .cursor/commands 目录（Cursor 命令文件）
+.cursor/commands/
+
+# cursor-helper 目录：只允许提交报告文件
+# 忽略所有 diff 目录（临时文件）
+cursor-helper/**/diff/
+
+# 忽略所有 docs 目录（PRD和技术方案文档）
+cursor-helper/**/docs/
+
+# 忽略 rule_improvements.md（临时规则优化建议文件）
+cursor-helper/**/rule_improvements.md
+
+# 忽略 fix 目录下的修复计划文件（临时文件）
+cursor-helper/**/fix/fix_plan.md
+
+# 忽略评审报告中的 files 目录（详细的文件评审报告，diff 报告）
+cursor-helper/**/review/reports/files/
+
+# 备份文件（.bak）
+# ⚠️ 重要提示：如果因为 Cursor 无法访问文件而通过文件操作命令修改文件时，可能会遗留 .bak 备份文件
+# 这些备份文件应该被忽略，请记得及时删除遗留的 .bak 文件
+*.bak
+
+# 保留所有报告文件：
+# - cursor-helper/**/review/reports/summary/** （总结性评审报告）
+# - cursor-helper/**/fix/fix_report.md （修复报告）
+# - cursor-helper/**/organize-rules/** （规则整理报告）

--- a/campaign/event_20260520_cn/b2.py
+++ b/campaign/event_20260520_cn/b2.py
@@ -64,6 +64,9 @@ class Config(ConfigBase):
     MAP_WALK_USE_CURRENT_FLEET = True
     # ===== End of generated config =====
 
+    HOMO_STORAGE = ((8, 6), [(137.405, 104.804), (1046.044, 104.804), (-12.171, 652.093), (1166.717, 652.093)])
+    MAP_ENSURE_EDGE_INSIGHT_CORNER = 'bottom-right'
+
 
 class Campaign(CampaignBase):
     MAP = MAP

--- a/campaign/event_20260520_cn/d2.py
+++ b/campaign/event_20260520_cn/d2.py
@@ -65,6 +65,9 @@ class Config(ConfigBase):
     MAP_WALK_USE_CURRENT_FLEET = True
     # ===== End of generated config =====
 
+    HOMO_STORAGE = ((8, 6), [(137.405, 104.804), (1046.044, 104.804), (-12.171, 652.093), (1166.717, 652.093)])
+    MAP_ENSURE_EDGE_INSIGHT_CORNER = 'bottom-right'
+
 
 class Campaign(CampaignBase):
     MAP = MAP

--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -19,9 +19,10 @@ from module.config.server import VALID_CHANNEL_PACKAGE, VALID_PACKAGE, set_serve
 from module.device.connection_attr import ConnectionAttr
 from module.device.env import IS_LINUX, IS_MACINTOSH, IS_WINDOWS
 from module.device.method.pool import WORKER_POOL
+from module.device.method.remove_warning import remove_shell_warning
 from module.device.method.utils import (PackageNotInstalled, RETRY_TRIES, get_serial_pair, handle_adb_error,
                                         handle_unknown_host_service, possible_reasons, random_port, recv_all,
-                                        remove_shell_warning, retry_sleep)
+                                        retry_sleep)
 from module.exception import EmulatorNotRunningError, RequestHumanTakeover
 from module.logger import logger
 from module.map.map_grids import SelectedGrids

--- a/module/device/method/adb.py
+++ b/module/device/method/adb.py
@@ -10,8 +10,9 @@ from lxml import etree
 from module.base.decorator import Config
 from module.config.server import DICT_PACKAGE_TO_ACTIVITY
 from module.device.connection import Connection
+from module.device.method.remove_warning import remove_screenshot_warning
 from module.device.method.utils import (ImageTruncated, PackageNotInstalled, RETRY_TRIES, handle_adb_error,
-                                        handle_unknown_host_service, remove_prefix, retry_sleep)
+                                        handle_unknown_host_service, retry_sleep)
 from module.exception import EmulatorNotRunningError, RequestHumanTakeover, ScriptError
 from module.logger import logger
 
@@ -136,10 +137,7 @@ class Adb(Connection):
         else:
             raise ScriptError(f'Unknown method to load screenshots: {method}')
 
-        # fix compatibility issues for adb screencap decode problem when the data is from vmos pro
-        # When use adb screencap for a screenshot from vmos pro, there would be a header more than that from emulator
-        # which would cause image decode problem. So i check and remove the header there.
-        screenshot = remove_prefix(screenshot, b'long long=8 fun*=10\n')
+        screenshot = remove_screenshot_warning(screenshot)
 
         if screenshot is None or len(screenshot) == 0:
             raise ImageTruncated('Empty screenshot payload in __load_screenshot')
@@ -185,6 +183,7 @@ class Adb(Connection):
     @Config.when(DEVICE_OVER_HTTP=True)
     def screenshot_adb(self):
         data = self.adb_shell(['screencap'], stream=True)
+        data = remove_screenshot_warning(data)
         if len(data) < 500:
             logger.warning(f'Unexpected screenshot: {data}')
 
@@ -193,6 +192,7 @@ class Adb(Connection):
     @retry
     def screenshot_adb_nc(self):
         data = self.adb_shell_nc(['screencap'])
+        data = remove_screenshot_warning(data)
         if len(data) < 500:
             logger.warning(f'Unexpected screenshot: {data}')
 

--- a/module/device/method/remove_warning.py
+++ b/module/device/method/remove_warning.py
@@ -1,0 +1,122 @@
+from typing import overload
+
+
+@overload
+def remove_shell_warning(s: bytes) -> bytes: ...
+
+
+@overload
+def remove_shell_warning(s: str) -> str: ...
+
+
+def remove_shell_warning(s):
+    """
+    Remove warnings from shell
+
+    1. Warnings in VMOS shell
+    https://github.com/LmeSzinc/AzurLaneAutoScript/issues/1425
+
+    WARNING: linker: [vdso]: unused DT entry: type 0x70000001 arg 0x0\n
+    \x89PNG\r\n\x1a\n\x00\x00\x00\rIH...
+
+    2. This linker thingy might appear multiple times when executing multiple commands
+
+    mek_8q:/dev # getprop | grep gnss
+    WARNING: linker: Warning: "[vdso]" unused DT entry: unknown processor-specific (type 0x70000001 arg 0x0) (ignoring)
+    WARNING: linker: Warning: "[vdso]" unused DT entry: unknown processor-specific (type 0x70000001 arg 0x0) (ignoring)
+    [init.svc.gnss_service]: [running]
+    [init.svc_debug_pid.gnss_service]: [406]
+    [ro.boottime.gnss_service]: [27308752875]
+
+    Args:
+        s (str | bytes): bytes or str
+
+    Returns:
+        str | bytes: Shell output with warnings removed
+    """
+    if isinstance(s, bytes):
+        while 1:
+            if s.startswith(b'WARNING: linker:'):
+                _, _, s = s.partition(b'\n')
+            else:
+                break
+    elif isinstance(s, str):
+        while 1:
+            if s.startswith('WARNING: linker:'):
+                _, _, s = s.partition('\n')
+            else:
+                break
+
+    return s
+
+
+@overload
+def remove_screenshot_warning(s: bytes) -> bytes: ...
+
+
+@overload
+def remove_screenshot_warning(s: str) -> str: ...
+
+
+def remove_screenshot_warning(s):
+    """
+    Remove warnings when taking screenshot
+
+    1. Errors in waydroid screencap render
+    https://github.com/LmeSzinc/AzurLaneAutoScript/issues/4760
+
+    Failed to create //.cache for shader cache (Read-only file system)---disabling.\n
+
+    2. Warning when taking screenshot from multiscreen device
+
+    [Warning] Multiple displays were found, but no display id was specified! Defaulting to the first display found,
+    however this default is not guaranteed to be consistent across captures.\n
+    A display id should be specified.\n
+    See "dumpsys SurfaceFlinger --display-id" for valid display IDs.\n
+    \x89PNG...
+
+    3. Another format of multiscreen warning
+    https://github.com/LmeSzinc/AzurLaneAutoScript/issues/5682
+
+    [Warning] Multiple displays were found, but no display id was specified! Defaulting to the first display found,
+    however this default is not guaranteed to be consistent across captures. A display id should be specified.\n
+    A display ID can be specified with the [-d display-id] option.\n
+    See "dumpsys SurfaceFlinger --display-id" for valid display IDs.\n
+    \x89PNG...
+
+    4. Unknown header on VMOS PRO screenshot
+    https://github.com/LmeSzinc/AzurLaneAutoScript/pull/940
+
+    long long=8 fun*=10\n\x89PNG...
+
+    Args:
+        s (str | bytes): bytes or str
+
+    Returns:
+        str | bytes: Screenshot data with warnings removed
+    """
+    if isinstance(s, bytes):
+        if s.startswith(b'Failed to create'):
+            _, _, s = s.partition(b'\n')
+        if s.startswith(b'[Warning] Multiple displays'):
+            _, _, s = s.partition(b'\n')
+            if s.startswith(b'A display id') or s.startswith(b'A display ID'):
+                _, _, s = s.partition(b'\n')
+                if s.startswith(b'See "dumpsys'):
+                    _, _, s = s.partition(b'\n')
+        if s.startswith(b'long long=8'):
+            _, _, s = s.partition(b'\n')
+
+    elif isinstance(s, str):
+        if s.startswith('Failed to create'):
+            _, _, s = s.partition('\n')
+        if s.startswith('[Warning] Multiple displays'):
+            _, _, s = s.partition('\n')
+            if s.startswith('A display id') or s.startswith('A display ID'):
+                _, _, s = s.partition('\n')
+                if s.startswith('See "dumpsys'):
+                    _, _, s = s.partition('\n')
+        if s.startswith('long long=8'):
+            _, _, s = s.partition('\n')
+
+    return s

--- a/module/device/method/utils.py
+++ b/module/device/method/utils.py
@@ -10,6 +10,8 @@ import uiautomator2cache
 from adbutils import AdbTimeout
 from lxml import etree
 
+from module.device.method.remove_warning import remove_shell_warning
+
 try:
     # adbutils 0.x
     from adbutils import _AdbStreamConnection as AdbConnection
@@ -376,74 +378,6 @@ def remove_suffix(s, suffix):
         str, bytes:
     """
     return s[:-len(suffix)] if s.endswith(suffix) else s
-
-
-def remove_shell_warning(s):
-    """
-    Remove warnings from shell
-
-    1. Warnings in VMOS shell
-    https://github.com/LmeSzinc/AzurLaneAutoScript/issues/1425
-
-    WARNING: linker: [vdso]: unused DT entry: type 0x70000001 arg 0x0\n\x89PNG\r\n\x1a\n\x00\x00\x00\rIH
-
-    2. This linker thingy might appear multiple times when executing multiple commands
-
-    mek_8q:/dev # getprop | grep gnss
-    WARNING: linker: Warning: "[vdso]" unused DT entry: unknown processor-specific (type 0x70000001 arg 0x0) (ignoring)
-    WARNING: linker: Warning: "[vdso]" unused DT entry: unknown processor-specific (type 0x70000001 arg 0x0) (ignoring)
-    [init.svc.gnss_service]: [running]
-    [init.svc_debug_pid.gnss_service]: [406]
-    [ro.boottime.gnss_service]: [27308752875]
-
-    3. Errors in waydroid screencap render
-    https://github.com/LmeSzinc/AzurLaneAutoScript/issues/4760
-
-    Failed to create //.cache for shader cache (Read-only file system)---disabling.\n
-
-    4. Warning when taking screenshot from multiscreen device
-
-    [Warning] Multiple displays were found, but no display id was specified! Defaulting to the first display found,
-    however this default is not guaranteed to be consistent across captures.\n
-    A display id should be specified.\n
-    See "dumpsys SurfaceFlinger --display-id" for valid display IDs.\n
-    \x89PNG...
-
-    Args:
-        s (T): bytes or str
-
-    Returns:
-        T:
-    """
-    if isinstance(s, bytes):
-        while 1:
-            if s.startswith(b'WARNING: linker:'):
-                _, _, s = s.partition(b'\n')
-            else:
-                break
-        if s.startswith(b'Failed to create'):
-            _, _, s = s.partition(b'\n')
-        if s.startswith(b'[Warning] Multiple displays'):
-            _, _, s = s.partition(b'\n')
-            if s.startswith(b'A display id'):
-                _, _, s = s.partition(b'\n')
-                if s.startswith(b'See "dumpsys'):
-                    _, _, s = s.partition(b'\n')
-    elif isinstance(s, str):
-        while 1:
-            if s.startswith('WARNING: linker:'):
-                _, _, s = s.partition('\n')
-            else:
-                break
-        if s.startswith('Failed to create'):
-            _, _, s = s.partition('\n')
-        if s.startswith('[Warning] Multiple displays'):
-            _, _, s = s.partition('\n')
-            if s.startswith('A display id'):
-                _, _, s = s.partition('\n')
-                if s.startswith('See "dumpsys'):
-                    _, _, s = s.partition('\n')
-    return s
 
 
 class IniterNoMinicap(u2.init.Initer):

--- a/module/event/campaign_sp.py
+++ b/module/event/campaign_sp.py
@@ -2,6 +2,7 @@ import os
 
 from module.config.config import TaskEnd
 from module.event.base import EventBase
+from module.exception import RequestHumanTakeover
 from module.logger import logger
 
 
@@ -18,7 +19,21 @@ class CampaignSP(EventBase):
         except TaskEnd:
             # Catch task switch
             pass
+        except RequestHumanTakeover:
+            # Daily SP already completed, delay to next day
+            logger.info('Daily SP already completed or unable to enter')
+            logger.info('Delaying task to next day')
+            self.config.task_delay(server_update=True)
+            return
+        
+        # Check if SP was successfully executed
         if self.run_count > 0:
+            # SP completed successfully, delay to next day
+            logger.info(f'SP completed successfully, run_count={self.run_count}')
             self.config.task_delay(server_update=True)
         else:
-            self.config.task_stop()
+            # SP failed to execute (possibly already completed today)
+            # Delay task to next day instead of stopping
+            logger.info('SP failed to execute, possibly already completed today')
+            logger.info('Delaying task to next day')
+            self.config.task_delay(server_update=True)

--- a/module/hard/hard.py
+++ b/module/hard/hard.py
@@ -94,27 +94,41 @@ class CampaignHard(CampaignRun):
         # 加载战役模块
         self.load_campaign(name='campaign_hard', folder='campaign_hard')
 
-        # 获取剩余次数
+        cursor = self.config.Hard_HardNewCursor
+        first_stage = stages[cursor % len(stages)]
+
+        # 先导航到第一个关卡再OCR剩余次数
+        map_name = to_map_file_name(first_stage)
+        module = importlib.import_module('.' + map_name, 'campaign.campaign_main')
+        self.campaign.MAP = module.MAP
         self.device.screenshot()
+        self.campaign.device.image = self.device.image
+        self.campaign.ensure_campaign_ui(name=first_stage, mode='hard')
         remain = OCR_HARD_REMAIN.ocr(self.device.image)
         logger.attr('Remain', remain)
 
-        cursor = self.config.Hard_HardNewCursor
-        for i in range(remain):
+        if remain == 0:
+            self.campaign.ensure_auto_search_exit()
+            self.config.task_delay(server_update=True)
+            self.config.task_call('Reward', force_call=False)
+            return
+
+        # 第一天关已导航好，直接打
+        self.campaign.run()
+        cursor += 1
+
+        for i in range(remain - 1):
             stage = stages[cursor % len(stages)]
             logger.attr('CurrentStage', stage)
 
-            # 加载当前关卡的地图数据
             map_name = to_map_file_name(stage)
             module = importlib.import_module('.' + map_name, 'campaign.campaign_main')
             self.campaign.MAP = module.MAP
 
-            # 导航到当前关卡
             self.device.screenshot()
             self.campaign.device.image = self.device.image
             self.campaign.ensure_campaign_ui(name=stage, mode='hard')
 
-            # 执行战斗
             self.campaign.run()
             cursor += 1
 

--- a/module/map/map_fleet_preparation.py
+++ b/module/map/map_fleet_preparation.py
@@ -269,8 +269,17 @@ class FleetOperator:
 
         # Cropping FLEET_*_IN_USE to avoid detecting info_bar, also do the trick.
         # It also avoids wasting time on handling the info_bar.
-        image = rgb2gray(self.main.image_crop(self._in_use.button, copy=False))
-        return np.std(image.flatten(), ddof=1) > self.FLEET_IN_USE_STD
+        image = self.main.image_crop(self._in_use.button, copy=False)
+
+        # special fix for Perseus skin, which color is so flat
+        # https://github.com/LmeSzinc/AzurLaneAutoScript/issues/5678
+        # no ship is in color (71, 70, 63)
+        color = cv2.mean(image)[:3]
+        if color_similar(color, (224, 154, 114), threshold=30):
+            return True
+
+        gray = rgb2gray(image)
+        return np.std(gray.flatten(), ddof=1) > self.FLEET_IN_USE_STD
 
     def bar_opened(self):
         """

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -1034,22 +1034,28 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
     # ========== 短猫提前开始计算 ==========
 
     def _get_current_action_point_value(self) -> tuple[int, str]:
-        """获取当前行动力，避免依赖统计模块。
+        """获取当前可用总体力，包含行动力箱子。
 
         Returns:
             tuple[int, str]: (行动力数值, 数据来源)
-            - 数据来源: realtime / cache / none
+            - 数据来源: cache / dashboard / none
         """
-        try:
-            return int(self.get_action_point()), 'realtime'
-        except Exception:
-            cached_ap = getattr(self, '_action_point_total', None)
-            if cached_ap is None:
-                return 0, 'none'
+        if '_action_point_total' in self.__dict__:
             try:
-                return int(cached_ap), 'cache'
-            except Exception:
-                return 0, 'none'
+                return int(self.__dict__['_action_point_total']), 'cache'
+            except (TypeError, ValueError):
+                pass
+
+        try:
+            dashboard_ap = self.config.cross_get(
+                keys='Dashboard.ActionPoint.Total', default=None
+            )
+            if dashboard_ap is not None:
+                return int(dashboard_ap), 'dashboard'
+        except (TypeError, ValueError):
+            pass
+
+        return 0, 'none'
 
     def _get_meow_avg_round_time_seconds(self) -> tuple[float, str]:
         """获取短猫平均每轮耗时（秒）。

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -2,6 +2,7 @@
 import sqlite3
 import json
 import os
+from contextlib import suppress
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
@@ -14,6 +15,16 @@ from module.logger import logger
 
 
 class Cl1Database:
+    @staticmethod
+    def _coerce_int(value: Any) -> int:
+        """严格转换为 int；无效输入由调用方按上下文捕获处理。"""
+        return int(value)
+
+    @staticmethod
+    def _coerce_float(value: Any) -> float:
+        """严格转换为 float；无效输入由调用方按上下文捕获处理。"""
+        return float(value)
+
     def _empty_siren_research_devices(self) -> dict:
         return {"cl1": 0, "meow": {}}
 
@@ -45,10 +56,13 @@ class Cl1Database:
         if source == "meow":
             if hazard_level is None:
                 return sum(
-                    int(value or 0) for value in devices.get("meow", {}).values()
+                    self._coerce_int(value or 0)
+                    for value in devices.get("meow", {}).values()
                 )
-            return int(devices.get("meow", {}).get(str(int(hazard_level)), 0) or 0)
-        return int(devices.get("cl1", 0) or 0)
+            return self._coerce_int(
+                devices.get("meow", {}).get(str(self._coerce_int(hazard_level)), 0) or 0
+            )
+        return self._coerce_int(devices.get("cl1", 0) or 0)
 
     def add_siren_research_device(
         self, instance: str, source: str = "cl1", hazard_level: int = None
@@ -68,7 +82,7 @@ class Cl1Database:
             devices["cl1"] = devices.get("cl1", 0) + 1
         elif source == "meow":
             meow = devices.get("meow", {})
-            key = str(int(hazard_level or 0))
+            key = str(self._coerce_int(hazard_level or 0))
             meow[key] = int(meow.get(key, 0) or 0) + 1
             devices["meow"] = meow
         data["siren_research_devices"] = devices
@@ -79,7 +93,7 @@ class Cl1Database:
         entries.append({
             "ts": datetime.now().isoformat(),
             "source": source,
-            "hazard_level": int(hazard_level or 0) if source == "meow" else None,
+            "hazard_level": self._coerce_int(hazard_level or 0) if source == "meow" else None,
         })
         if len(entries) > 5000:
             entries = entries[-5000:]
@@ -163,8 +177,7 @@ class Cl1Database:
                 updated_rows = []
                 for instance, month, blob in rows:
                     # 1. 用旧密钥解密
-                    data = self._decrypt_with_key(blob, old_key)
-                    if data:
+                    if data := self._decrypt_with_key(blob, old_key):
                         # 2. 用新密钥重加密 (self._encrypt 使用的是当前 self._encryption_key)
                         new_blob = self._encrypt(data)
                         updated_rows.append((new_blob, instance, month))
@@ -180,17 +193,20 @@ class Cl1Database:
         except Exception as e:
             logger.error(f"Failed to migrate database to new device_id: {e}")
 
+    def _decrypt_payload(self, blob: bytes, key: bytes) -> Dict[str, Any]:
+        nonce = blob[:16]
+        tag = blob[16:32]
+        ciphertext = blob[32:]
+        cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+        return json.loads(plaintext.decode("utf-8"))
+
     def _decrypt_with_key(self, blob: bytes, key: bytes) -> Optional[Dict[str, Any]]:
         """辅助方法：使用指定密钥进行解密"""
         if not blob or len(blob) < 32:
             return None
         try:
-            nonce = blob[:16]
-            tag = blob[16:32]
-            ciphertext = blob[32:]
-            cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
-            plaintext = cipher.decrypt_and_verify(ciphertext, tag)
-            return json.loads(plaintext.decode("utf-8"))
+            return self._decrypt_payload(blob, key)
         except Exception:
             return None
 
@@ -212,12 +228,7 @@ class Cl1Database:
         if not blob or len(blob) < 32:
             return None
         try:
-            nonce = blob[:16]
-            tag = blob[16:32]
-            ciphertext = blob[32:]
-            cipher = AES.new(self._encryption_key, AES.MODE_GCM, nonce=nonce)
-            plaintext = cipher.decrypt_and_verify(ciphertext, tag)
-            return json.loads(plaintext.decode("utf-8"))
+            return self._decrypt_payload(blob, self._encryption_key)
         except (ValueError, KeyError) as e:
             logger.error(f"Decryption failed (Tamper detected or Wrong key): {e}")
             return None
@@ -235,10 +246,8 @@ class Cl1Database:
                     (instance, month),
                 )
                 row = cursor.fetchone()
-                if row:
-                    data = self._decrypt(row[0])
-                    if data:
-                        return data
+                if row and (data := self._decrypt(row[0])):
+                    return data
         except Exception as e:
             logger.error(f"Failed to query stats for {instance} {month}: {e}")
 
@@ -289,11 +298,7 @@ class Cl1Database:
     @staticmethod
     def _get_meow_battles_per_round(hazard_level: Optional[int]) -> Optional[int]:
         """根据侵蚀等级返回每轮战斗次数。"""
-        if hazard_level in [2, 3]:
-            return 2
-        if hazard_level in [4, 5, 6]:
-            return 3
-        return None
+        return 2 if hazard_level in {2, 3} else 3 if hazard_level in {4, 5, 6} else None
 
     def _normalize_meow_hazard_stats(
         self, data: Dict[str, Any]
@@ -309,7 +314,7 @@ class Cl1Database:
                 hazard_level = int(hazard_key)
             except (TypeError, ValueError):
                 continue
-            if hazard_level not in [2, 3, 4, 5, 6] or not isinstance(bucket, dict):
+            if hazard_level not in {2, 3, 4, 5, 6} or not isinstance(bucket, dict):
                 continue
 
             round_times = bucket.get("round_times", [])
@@ -320,9 +325,9 @@ class Cl1Database:
                 if isinstance(entry, (int, float)):
                     normalized_round_times.append(float(entry))
                 elif isinstance(entry, dict) and isinstance(
-                    entry.get("duration"), (int, float)
+                    duration := entry.get("duration"), (int, float)
                 ):
-                    normalized_round_times.append(float(entry.get("duration")))
+                    normalized_round_times.append(float(duration))
 
             battle_times = bucket.get("battle_times", [])
             if not isinstance(battle_times, list):
@@ -332,9 +337,9 @@ class Cl1Database:
                 if isinstance(entry, (int, float)):
                     normalized_battle_times.append(float(entry))
                 elif isinstance(entry, dict) and isinstance(
-                    entry.get("duration"), (int, float)
+                    duration := entry.get("duration"), (int, float)
                 ):
-                    normalized_battle_times.append(float(entry.get("duration")))
+                    normalized_battle_times.append(float(duration))
 
             try:
                 battle_raw_count = int(bucket.get("battle_raw_count", 0) or 0)
@@ -384,7 +389,7 @@ class Cl1Database:
         for entry in round_times:
             if isinstance(entry, dict):
                 hazard_level = entry.get("hazard_level")
-                if hazard_level in [2, 3, 4, 5, 6]:
+                if hazard_level in {2, 3, 4, 5, 6}:
                     hazard_levels.append(hazard_level)
 
         if not hazard_levels:
@@ -432,10 +437,12 @@ class Cl1Database:
         by_battle_times = len(battle_times) if battle_times else 0
         should_save = False
 
-        need_backfill = raw_battle_count is None
-        if estimated_from_rounds is not None and current_raw > 0:
-            if current_raw < int(estimated_from_rounds * 0.85):
-                need_backfill = True
+        need_backfill = (
+            raw_battle_count is None
+            or estimated_from_rounds is not None
+            and current_raw > 0
+            and current_raw < int(estimated_from_rounds * 0.85)
+        )
 
         if need_backfill:
             candidates = [
@@ -443,25 +450,23 @@ class Cl1Database:
                 for candidate in [current_raw, estimated_from_rounds, by_battle_times]
                 if candidate is not None
             ]
-            raw_battle_count = (
-                max(candidates) if candidates else int(round(effective_rounds))
-            )
+            raw_battle_count = max(candidates, default=int(round(effective_rounds)))
             data["meow_battle_raw_count"] = int(raw_battle_count)
             should_save = True
 
-            if inferred_divisor in [2, 3] and effective_rounds > 0:
+            if inferred_divisor in {2, 3} and effective_rounds > 0:
                 data["meow_battle_count"] = round(
-                    int(raw_battle_count) / inferred_divisor, 2
+                    raw_battle_count / inferred_divisor, 2
                 )
                 effective_rounds = float(data["meow_battle_count"])
         else:
             raw_battle_count = current_raw
 
-        if int(raw_battle_count) > 0 and effective_rounds > 0:
-            ratio = float(raw_battle_count) / float(effective_rounds)
+        if raw_battle_count > 0 and effective_rounds > 0:
+            ratio = raw_battle_count / effective_rounds
             if ratio > 5:
-                divisor_for_fix = inferred_divisor if inferred_divisor in [2, 3] else 3
-                fixed_rounds = round(int(raw_battle_count) / divisor_for_fix, 2)
+                divisor_for_fix = inferred_divisor if inferred_divisor in {2, 3} else 3
+                fixed_rounds = round(raw_battle_count / divisor_for_fix, 2)
                 if abs(fixed_rounds - effective_rounds) > 0.01:
                     data["meow_battle_count"] = fixed_rounds
                     effective_rounds = float(fixed_rounds)
@@ -628,28 +633,30 @@ class Cl1Database:
         yellow_coin = 0
         yellow_coin_snapshots = data.get("yellow_coin_snapshots", [])
         if yellow_coin_snapshots:
-            try:
+            with suppress(ValueError, TypeError, IndexError, KeyError):
                 yellow_coin = int(yellow_coin_snapshots[-1].get("yellow_coin", 0))
-            except Exception:
-                pass
 
-        # 资产 = AP × 效率 + 黄币
-        asset = ap_current * cl5_efficiency + yellow_coin
+        # 资产按可用总体力计算，包含行动力箱子。
+        ap_current = self._coerce_int(ap_current)
+        if ap_total is not None:
+            ap_total = self._coerce_int(ap_total)
+        ap_for_asset = ap_total if ap_total is not None else ap_current
+        asset = ap_for_asset * cl5_efficiency + yellow_coin
         # 虚拟资产 = 资产 + 时间加成
         virtual_asset = asset + virtual_asset_added
 
         snapshot = {
             "ts": now.isoformat(),
-            "ap": int(ap_current),
-            "yellow_coin": int(yellow_coin),
+            "ap": ap_current,
+            "yellow_coin": yellow_coin,
             "asset": round(asset, 2),
             "virtual_asset": round(virtual_asset, 2),
             "source": source,
         }
         if distance is not None:
-            snapshot["distance"] = int(distance)
+            snapshot["distance"] = self._coerce_int(distance)
         if ap_total is not None:
-            snapshot["ap_total"] = int(ap_total)
+            snapshot["ap_total"] = ap_total
 
         snapshots = data.get("ap_snapshots", [])
         snapshots.append(snapshot)
@@ -681,7 +688,7 @@ class Cl1Database:
         data = self.get_stats(instance, month)
         data["last_ap_notification"] = {
             "ts": datetime.now().isoformat(),
-            "ap": int(ap_current),
+            "ap": self._coerce_int(ap_current),
         }
         self.save_stats(instance, month, data)
 
@@ -697,20 +704,19 @@ class Cl1Database:
         """
         month = datetime.now().strftime("%Y-%m")
         data = self.get_stats(instance, month)
+        yellow_coin = self._coerce_int(yellow_coin)
 
         snapshot = {
             "ts": datetime.now().isoformat(),
-            "yellow_coin": int(yellow_coin),
+            "yellow_coin": yellow_coin,
             "source": source,
         }
 
         snapshots = data.get("yellow_coin_snapshots", [])
         if snapshots:
-            try:
-                if int(snapshots[-1].get("yellow_coin", -1)) == int(yellow_coin):
+            with suppress(ValueError, TypeError, IndexError, KeyError):
+                if self._coerce_int(snapshots[-1].get("yellow_coin", -1)) == yellow_coin:
                     return
-            except Exception:
-                pass
         snapshots.append(snapshot)
         data["yellow_coin_snapshots"] = snapshots
         self.save_stats(instance, month, data)
@@ -732,28 +738,29 @@ class Cl1Database:
         """
         month = datetime.now().strftime("%Y-%m")
         data = self.get_stats(instance, month)
+        yellow_coins = self._coerce_int(yellow_coins)
+        purple_coins = self._coerce_int(purple_coins) if purple_coins is not None else None
 
         snapshot = {
             "ts": datetime.now().isoformat(),
-            "yellow_coins": int(yellow_coins),
+            "yellow_coins": yellow_coins,
             "source": source,
         }
         if purple_coins is not None:
-            snapshot["purple_coins"] = int(purple_coins)
+            snapshot["purple_coins"] = purple_coins
 
         snapshots = data.get("coins_snapshots", [])
         if snapshots:
-            try:
+            with suppress(ValueError, TypeError, IndexError, KeyError):
                 last = snapshots[-1]
-                if int(last.get("yellow_coins", -1)) == int(yellow_coins):
-                    if purple_coins is not None and int(
-                        last.get("purple_coins", -1)
-                    ) == int(purple_coins):
+                if self._coerce_int(last.get("yellow_coins", -1)) == yellow_coins:
+                    if (
+                        purple_coins is not None
+                        and self._coerce_int(last.get("purple_coins", -1)) == purple_coins
+                    ):
                         return
                     if purple_coins is None and "purple_coins" not in last:
                         return
-            except Exception:
-                pass
         snapshots.append(snapshot)
         # 保留最近 500 条记录，避免数据过大
         if len(snapshots) > 500:
@@ -790,10 +797,11 @@ class Cl1Database:
 
             # JSON 格式比较杂乱，需要按月份归档
             # 格式可能是: {"2026-02": 10, "2026-02-akashi": 1, "2026-02-akashi-ap": 120, "2026-02-akashi-ap-entries": [...]}
-            months = set()
-            for key in old_data.keys():
-                if len(key) >= 7 and key[4] == "-":
-                    months.add(key[:7])
+            months = {
+                key[:7]
+                for key in old_data
+                if len(key) >= 7 and key[4] == "-"
+            }
 
             for month in months:
                 # 首先检查数据库是否已有数据，避免覆盖
@@ -879,10 +887,10 @@ class Cl1Database:
         if delta is not None:
             # 直接使用 delta，保持向后兼容
             try:
-                delta = float(delta)
+                delta = self._coerce_float(delta)
             except Exception:
                 delta = 1
-        elif hazard_level is not None and hazard_level in [2, 3, 4, 5, 6]:
+        elif hazard_level in {2, 3, 4, 5, 6}:
             battles_per_round = self._get_meow_battles_per_round(hazard_level)
             delta = (1 / battles_per_round) if battles_per_round else 1
         else:
@@ -893,13 +901,13 @@ class Cl1Database:
         data["meow_battle_raw_count"] = data.get("meow_battle_raw_count", 0) + 1
         data["meow_battle_count"] = data.get("meow_battle_count", 0) + delta
 
-        if hazard_level in [2, 3, 4, 5, 6]:
+        if hazard_level in {2, 3, 4, 5, 6}:
             hazard_stats = self._normalize_meow_hazard_stats(data)
             bucket = self._ensure_meow_hazard_bucket(hazard_stats, hazard_level)
             bucket["battle_raw_count"] = int(bucket.get("battle_raw_count", 0) or 0) + 1
             bucket["effective_rounds"] = float(
                 bucket.get("effective_rounds", 0) or 0
-            ) + float(delta)
+            ) + delta
             data["meow_hazard_stats"] = hazard_stats
 
         self.save_stats(instance, month, data)
@@ -915,7 +923,7 @@ class Cl1Database:
             hazard_level: 侵蚀等级，用于计算出击轮次（2-6）
         """
         # 验证 hazard_level 是否在有效范围内
-        if hazard_level is not None and hazard_level not in [2, 3, 4, 5, 6]:
+        if hazard_level is not None and hazard_level not in {2, 3, 4, 5, 6}:
             logger.debug(f"Invalid hazard_level {hazard_level}, ignoring")
             hazard_level = None
 
@@ -936,7 +944,7 @@ class Cl1Database:
 
         data["meow_round_times"] = normalized_times
 
-        if hazard_level in [2, 3, 4, 5, 6]:
+        if hazard_level in {2, 3, 4, 5, 6}:
             hazard_stats = self._normalize_meow_hazard_stats(data)
             bucket = self._ensure_meow_hazard_bucket(hazard_stats, hazard_level)
             round_times = bucket.get("round_times", [])
@@ -958,7 +966,7 @@ class Cl1Database:
             duration: 战斗耗时（秒）
             hazard_level: 侵蚀等级（2-6），用于分级统计
         """
-        if hazard_level is not None and hazard_level not in [2, 3, 4, 5, 6]:
+        if hazard_level is not None and hazard_level not in {2, 3, 4, 5, 6}:
             logger.debug(f"Invalid hazard_level {hazard_level}, ignoring")
             hazard_level = None
 
@@ -977,7 +985,7 @@ class Cl1Database:
 
         data["meow_battle_times"] = times
 
-        if hazard_level in [2, 3, 4, 5, 6]:
+        if hazard_level in {2, 3, 4, 5, 6}:
             hazard_stats = self._normalize_meow_hazard_stats(data)
             bucket = self._ensure_meow_hazard_bucket(hazard_stats, hazard_level)
             battle_times = bucket.get("battle_times", [])
@@ -1045,13 +1053,13 @@ class Cl1Database:
         hazard_round_samples: Dict[int, List[float]] = {3: [], 5: []}
         for entry in normalized_round_times:
             hl = entry.get("hazard_level")
-            if hl in [2, 3, 4, 5, 6]:
+            if hl in {2, 3, 4, 5, 6}:
                 hazard_sample_total += 1
-            if hl in [3, 5]:
+            if hl in {3, 5}:
                 hazard_round_samples[hl].append(entry["duration"])
 
         by_hazard: Dict[str, Dict[str, Any]] = {}
-        for hl in [3, 5]:
+        for hl in (3, 5):
             key_name = str(hl)
             bucket = hazard_stats.get(key_name, {})
 
@@ -1073,8 +1081,7 @@ class Cl1Database:
             hz_round_times = [
                 float(v) for v in hz_round_times if isinstance(v, (int, float))
             ]
-            if not hz_round_times:
-                hz_round_times = hazard_round_samples[hl]
+            hz_round_times = hz_round_times or hazard_round_samples[hl]
 
             hz_battle_times = (
                 bucket.get("battle_times", [])
@@ -1162,14 +1169,11 @@ class Cl1Database:
         }
 
         # 请求指定侵蚀等级时，将该等级数据提升到顶层
-        if hazard_level is not None:
-            hl_key = str(hazard_level)
-            if hl_key in by_hazard:
-                hl_data = by_hazard[hl_key]
-                result["battle_count"] = hl_data["battle_count"]
-                result["effective_rounds"] = hl_data["effective_rounds"]
-                result["avg_round_time"] = hl_data["avg_round_time"]
-                result["avg_battle_time"] = hl_data["avg_battle_time"]
+        if hazard_level is not None and (hl_data := by_hazard.get(str(hazard_level))):
+            result["battle_count"] = hl_data["battle_count"]
+            result["effective_rounds"] = hl_data["effective_rounds"]
+            result["avg_round_time"] = hl_data["avg_round_time"]
+            result["avg_battle_time"] = hl_data["avg_battle_time"]
 
         return result
 
@@ -1281,10 +1285,11 @@ class Cl1Database:
         month = datetime.now().strftime("%Y-%m")
         data = self.get_stats(instance, month)
 
+        commission_count = self._coerce_int(commission_count)
         entry = {
             "ts": datetime.now().isoformat(),
-            "items": {k: int(v) for k, v in items.items() if v > 0},
-            "commission_count": int(commission_count),
+            "items": {k: self._coerce_int(v) for k, v in items.items() if v > 0},
+            "commission_count": commission_count,
         }
 
         entries = data.get("commission_income_entries", [])
@@ -1309,10 +1314,8 @@ class Cl1Database:
         """
         if year is None or month is None:
             now = datetime.now()
-            if year is None:
-                year = now.year
-            if month is None:
-                month = now.month
+            year = year or now.year
+            month = month or now.month
 
         month_key = f"{year:04d}-{month:02d}"
         data = self.get_stats(instance, month_key)

--- a/module/statistics/opsi_month.py
+++ b/module/statistics/opsi_month.py
@@ -224,9 +224,11 @@ def get_virtual_asset_timeline(
     year: int | None = None, month: int | None = None, instance_name: str | None = None
 ) -> list:
     """
-    Get virtual asset timeline from ap_snapshots that contain virtual_asset data.
+    Get virtual asset timeline from AP snapshots.
 
-    Returns sorted list of snapshots with 'ts' and 'virtual_asset' fields.
+    Existing asset/virtual_asset snapshot fields are the display source of truth.
+    Older snapshots without these fields are still returned so the WebUI can
+    reconstruct them for display.
     """
     now = datetime.now()
     if year is None:
@@ -237,6 +239,4 @@ def get_virtual_asset_timeline(
 
     data = cl1_db.get_stats(instance_name or "default", key_prefix)
     snapshots = data.get("ap_snapshots", [])
-    return sorted(
-        [s for s in snapshots if "virtual_asset" in s], key=lambda e: e.get("ts", "")
-    )
+    return sorted([s for s in snapshots if s.get("ts")], key=lambda e: e.get("ts", ""))

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -485,6 +485,29 @@ class AlasGUI(Frame):
             from datetime import datetime as _dt
             import json as _json
 
+            def _get_cl5_efficiency():
+                default = 1700.0 / 30.0
+                try:
+                    config = getattr(self, "alas_config", None)
+                    if config is None or not hasattr(config, "cross_get"):
+                        return default
+                    meow5_coin = config.cross_get(
+                        "OpsiSimulator.OpsiSimulatorParameters.Meow5Coin"
+                    )
+                    if meow5_coin is not None:
+                        meow5_coin_float = float(meow5_coin)
+                        if meow5_coin_float > 0:
+                            return meow5_coin_float / 30.0
+                except (AttributeError, TypeError, ValueError):
+                    pass
+                return default
+
+            def _snapshot_float(point, key):
+                value = point.get(key)
+                if value is None:
+                    return None
+                return float(value)
+
             raw_points = []
             for pt in timeline:
                 ts_raw = pt.get("ts", "")
@@ -774,21 +797,39 @@ class AlasGUI(Frame):
 
             # Process virtual asset timeline
             if virtual_asset_timeline and current_view in ("line", "detail"):
+                from calendar import monthrange as _monthrange
+
                 for pt in virtual_asset_timeline:
                     ts_raw = pt.get("ts", "")
-                    va_val = pt.get("virtual_asset")
-                    a_val = pt.get("asset")
-                    if ts_raw and va_val is not None:
+                    if ts_raw:
                         try:
-                            va_val = float(va_val)
                             va_dt = _dt.fromisoformat(ts_raw)
-                            virtual_asset_list.append(va_val)
+                            asset_value = _snapshot_float(pt, "asset")
+                            virtual_asset_value = _snapshot_float(pt, "virtual_asset")
+                            if asset_value is None:
+                                ap_for_asset = int(pt.get("ap_total", pt.get("ap", 0)) or 0)
+                                yellow_coin_for_asset = int(pt.get("yellow_coin", 0) or 0)
+                                asset_value = (
+                                    ap_for_asset * _get_cl5_efficiency()
+                                    + yellow_coin_for_asset
+                                )
+                            if virtual_asset_value is None:
+                                month_end = va_dt.replace(
+                                    day=_monthrange(va_dt.year, va_dt.month)[1],
+                                    hour=23,
+                                    minute=59,
+                                    second=59,
+                                    microsecond=0,
+                                )
+                                virtual_asset_value = asset_value + max(
+                                    0,
+                                    (month_end - va_dt).total_seconds(),
+                                ) / 600.0 * _get_cl5_efficiency()
+                            virtual_asset_list.append(virtual_asset_value)
                             virtual_asset_ts_list.append(int(va_dt.timestamp() * 1000))
-                            # 从同一条快照中提取 asset
-                            if a_val is not None:
-                                asset_list.append(float(a_val))
-                                asset_ts_list.append(int(va_dt.timestamp() * 1000))
-                        except (TypeError, ValueError, Exception):
+                            asset_list.append(asset_value)
+                            asset_ts_list.append(int(va_dt.timestamp() * 1000))
+                        except (TypeError, ValueError):
                             continue
 
                 if virtual_asset_list:
@@ -1617,7 +1658,9 @@ class AlasGUI(Frame):
 
                         ap_timeline = get_ap_timeline(instance_name=instance_name_stat)
                         current_ap = (
-                            int(ap_timeline[-1].get("ap", 0)) if ap_timeline else 0
+                            int(ap_timeline[-1].get("ap_total", ap_timeline[-1].get("ap", 0)))
+                            if ap_timeline
+                            else 0
                         )
 
                         meow_round_ap = 30
@@ -3088,6 +3131,8 @@ class AlasGUI(Frame):
 
             if group_name not in self._log.last_display_time.keys():
                 self._log.last_display_time[group_name] = ""
+            if self._log.last_display_time[group_name] == delta and not self._log.first_display:
+                continue
             self._log.last_display_time[group_name] = delta
 
             # if self._log.first_display:


### PR DESCRIPTION
## 摘要
- **困难图均衡模式** — 新增 HardNewMode 开关，支持按驱逐/巡洋/战列/航母四类图纸勾选关卡，HardNewCursor 持久化指针跨天轮转
- Merge upstream_nanoda/master: 事件检测修复、Battle UI更新、大柱子处理

## 均衡模式逻辑
| 选中数 | 分配方式 |
|--------|----------|
| 1 个 | 固定刷该关卡 |
| 2 个 | 跨天交替 |
| 3 个 | 每天各一次 |
| 4 个 | 4天一轮各3次 |

## 变更文件
- `module/hard/hard.py` — 新增 `_run_balanced_mode()`
- `module/config/argument/argument.yaml` — 新增 7 个配置项
- `module/config/i18n/*.json` — 5 语言翻译
- `README.md` — 新增功能说明